### PR TITLE
Simplify the build commands for Sass

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
         <meta http-equiv="X-UA-Compatible" content="ie=edge" />
         <title>freeCodeCamp Elk Grove</title>
         <link href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" rel="stylesheet" />
-        <link href="css/style.css" rel="stylesheet" type="text/css" />
+        <link href="build/style.css" rel="stylesheet" type="text/css" />
     </head>
     <body>
         <div class="navigation">

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "script.js",
   "scripts": {
     "sass": "node-sass sass/main.scss build/style.css",
-    "compile": "node-sass sass/main.scss css/style.css"
+    "compile": "node-sass sass/main.scss build/style.css"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This will streamline the process for setting up the SASS files locally. Originally, I had two commands, one to build for deployment and one for local. The purpose of this is because we do not want our compiled css to be committed to Github. So we are .gitignoring any compiled css when comitting and rebuilding at the deploy step to inject back the css.